### PR TITLE
Fix compatibility issue with cordova-plugin-splashscreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ sample: $(TESTAPP_PATH)
 
 build: sample
 	cd $(TESTAPP_PATH); cordova build android
-	zip build/cordova-plugin-dialonce-$(shell date "+%d-%m-%Y").zip -r src package.json plugin.xml README.md
+	mkdir -p $(PWD)/build/sdk
+	zip build/sdk/cordova-plugin-dialonce-$(shell date "+%d-%m-%Y").zip -r src www package.json plugin.xml README.md
 
 publish:
 	npm login

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Install the dialonce-cordova plugin by executing:
 
 	$ cordova plugin add cordova-plugin-dialonce --variable ANDROID_API_KEY="<ANDROID_API_KEY>"
 
-
 ## Example
 
 	# Create initial Cordova app
@@ -62,3 +61,9 @@ Install the dialonce-cordova plugin by executing:
 	$ cd myApp/
 	$ cordova platform add android
 	$ cordova plugin add cordova-plugin-dialonce --variable ANDROID_API_KEY="<ANDROID_API_KEY>"
+
+## API
+
+Dial-Once SDK works as an autonomous component. One thing which needs to be done is to request for permissions. This can be done by `navigator.dialonce.requestPermissions()` call. 
+
+This is important becuase beginning in Android 6.0 (API level 23), users grant permissions to apps while the app is running, not when they install the app. And without these permissions, the SDK will not able to work properly.

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ dependencies:
 general:
   artifacts:
     - build/sample/platforms/android/build/outputs/apk/android-debug.apk
-    - build/cordova-plugin-dialonce-*.zip
+    - build/sdk
 
 test:
   pre:

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,9 +8,13 @@
     <keywords>dialonce,dialonce-cordova</keywords>
 
     <engines>
-      <engine name="cordova" version=">=3.0.0" />
-      <engine name="cordova-android" version=">=4.0.0" />
+        <engine name="cordova" version=">=3.0.0" />
+        <engine name="cordova-android" version=">=4.0.0" />
     </engines>
+
+    <js-module src="www/dialonce.js" name="DialOnce">
+        <clobbers target="navigator.dialonce" />
+    </js-module>
 
     <!-- android -->
     <platform name="android">
@@ -27,7 +31,7 @@
         </config-file>
         
         <config-file target="AndroidManifest.xml" parent="application">
-            <meta-data android:name="DIALONCE_API_KEY" android:value="$ANDROID_API_KEY"/>
+            <meta-data android:name="DIAL_ONCE_API_KEY" android:value="$ANDROID_API_KEY"/>
         </config-file>
 
         <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/DialOnceBridge.java
+++ b/src/android/DialOnceBridge.java
@@ -1,6 +1,9 @@
 package com.dialonce.sdk;
 
+import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.LOG;
+import org.json.JSONArray;
 import org.json.JSONException;
 
 import android.Manifest;
@@ -8,12 +11,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
+import android.text.TextUtils;
 
 import com.dialonce.sdk.DialOnce;
 
 public class DialOnceBridge extends CordovaPlugin {
 
-    String [] permissions = { Manifest.permission.INTERNET,
+    private static final String TAG = "dial-once-cordova";
+    private static final String[] permissions = { Manifest.permission.INTERNET,
             Manifest.permission.ACCESS_NETWORK_STATE,
             Manifest.permission.CALL_PHONE,
             Manifest.permission.PROCESS_OUTGOING_CALLS,
@@ -21,48 +27,68 @@ public class DialOnceBridge extends CordovaPlugin {
             Manifest.permission.VIBRATE,
             Manifest.permission.GET_TASKS,
             Manifest.permission.INSTALL_SHORTCUT };
-    private static int REQUEST_CODE_PERMISSION = 0;
+    private static final int REQUEST_CODE_PERMISSION = 0;
 
-    @Override protected void pluginInitialize() {
-        this.initDialOnce();
+    @Override 
+    protected void pluginInitialize() {
+        try {
+            Context context = cordova.getActivity().getApplicationContext();
+            ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(
+                    context.getPackageName(), PackageManager.GET_META_DATA);
+
+            String apiKey = applicationInfo.metaData.getString("DIAL_ONCE_API_KEY");
+
+            if (TextUtils.isEmpty(apiKey)) {
+                LOG.e(TAG, "ANDROID_API_KEY is empty. Have you set your ANDROID_API_KEY ?");
+            } else {
+                DialOnce.init(context, apiKey);
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasPermissions(permissions)) {
+                LOG.i(TAG, "Make sure that you called `navigator.dialonce.requestPermissions()` later"
+                        + " to grant all needed permissions");
+            }
+        } catch (Exception exception) {
+            LOG.e(TAG, "Something went wrong when initializing DialOnce :", exception);
+        }
     }
 
-    @Override public void onStart() {
-        //We also initialize Dial Once here just in case it has died. If Dial Once is already set up, this won't do anything.
-        this.initDialOnce();
-    }
-
-    @Override public void onNewIntent(Intent intent) {
+    @Override 
+    public void onNewIntent(Intent intent) {
         cordova.getActivity().setIntent(intent);
     }
 
-    private void initDialOnce() {
-        cordova.requestPermissions(this, REQUEST_CODE_PERMISSION, permissions);       
-    }
-
     @Override
-    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
-        super.onRequestPermissionResult(requestCode, permissions, grantResults);
-        if (requestCode == REQUEST_CODE_PERMISSION) {
-            for (int r : grantResults) {
-                if (r == PackageManager.PERMISSION_DENIED) {
-                    return;
-                }
-            }
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        if (action.equals("requestPermissions")) {
             cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
                 public void run() {
-                    try {
-                        Context context = cordova.getActivity().getApplicationContext();
-                        ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-
-                        DialOnce.init(context, applicationInfo.metaData.getString("DIALONCE_API_KEY"));
-                    } catch (Exception exception) {
-                        System.err.println("[dialonce-cordova] Something went wrong when initializing DialOnce: " + exception.getMessage());
-                        System.err.println("[dialonce-cordova] Have you set your ANDROID_API_KEY ?");
-                    }
+                    requestPermissions();
                 }
             });
+        } else {
+            return false;
         }
+
+        callbackContext.success();
+        return true;
+    }
+
+    private void requestPermissions() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (!hasPermissions(permissions)) {
+                cordova.requestPermissions(this, REQUEST_CODE_PERMISSION, permissions);
+            }
+        }
+    }
+
+    private boolean hasPermissions(String[] permissions) {
+        for (String perm : permissions) {
+            if (!cordova.hasPermission(perm)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/www/dialonce.js
+++ b/www/dialonce.js
@@ -1,0 +1,12 @@
+var exec = require('cordova/exec');
+
+var dialonce = {
+    /**
+     * Request permissions to ensure the SDK to work properly
+     */
+    requestPermissions: function() {
+        exec(null, null, "DialOnce", "requestPermissions", []);
+    }
+};
+
+module.exports = dialonce;


### PR DESCRIPTION
#### Changes

`requestPermissions` was added to API, so for now end developers may call `setTimeout(function() { navigator.dialonce.requestPermissions(); }, 5000);` and request permissions whenever they wannt